### PR TITLE
🆎 使用recover来避免panic时带来的错误

### DIFF
--- a/memcache_test.go
+++ b/memcache_test.go
@@ -107,7 +107,8 @@ func Test_RandomGet(t *testing.T) {
 func Test_Delete(t *testing.T) {
 	m := WithLRU[string](1, false)
 	m.Set("hello", "world")
-	if !reflect.DeepEqual(m.Get("hello"), "world") {
+	hello := m.Get("hello")
+	if hello == nil || *hello != "world" {
 		t.Logf("Error")
 		t.FailNow()
 	}


### PR DESCRIPTION
memcache.Get在某些特殊情况下，会导致空指针异常，目前查不到原因，这个推送主要解决空指针以后没有释放读写锁的bug